### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,29 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request: {}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+
+          # Show only new issues if it's a pull request.
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,10 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: WillAbides/setup-go-faster@v1
         with:
           go-version: '1.21'
-          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,5 @@ linters:
     - depguard
     - tagalign
     - godot
+    - gci
+    - gofumpt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,16 @@ linters:
     - bugs
     - error
     - unused
+    - comment
+    - format
+    - importTw
+    - metalinter
+    - module
+    - performance
+    - sql
   disable:
     - wrapcheck
     - goerr113
+    - depguard
+    - tagalign
+    - godot

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters:
     - unused
     - comment
     - format
-    - importTw
+    - import
     - metalinter
     - module
     - performance

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+linters:
+  presets:
+    - bugs
+    - error
+    - unused
+  disable:
+    - wrapcheck
+    - goerr113


### PR DESCRIPTION
This PR adds [golangci-lint](https://golangci-lint.run/) to hopefully catch errors and code style issues in PRs, with a custom configuration with some extra linters enabled and some (in my opinion) annoying ones disabled, along with a GitHub Actions workflow to run it on pushes and PRs.

Initially there's quite a few issues - follow-up PRs will start resolving them. This is the state when running on `liam.burnand/update-parent`:

```
$ golangci-lint run
role/db.go:21:1: commentFormatting: put a space between `//` and comment text (gocritic)
//func (s *Store) getUsersCountForRole(ctx context.Context, r Role) (i int, err error) {
^
role/db.go:31:1: commentFormatting: put a space between `//` and comment text (gocritic)
//func (s *Store) GetUsersForRole(ctx context.Context, r Role) (i User, err error) {
^
permission/permission.go:26:3: commentFormatting: put a space between `//` and comment text (gocritic)
		//ParentID     int    `db:"parent_id" json:"parentID"`
		^
public/templates/templates.go:99:10: unlambda: replace `func() time.Time {
	return time.Now()
}` with `time.Now` (gocritic)
		"now": func() time.Time {
		       ^
public/templates/templates.go:195:10: unlambda: replace `func() time.Time {
	return time.Now()
}` with `time.Now` (gocritic)
		"now": func() time.Time {
		       ^
public/templates/templates.go:314:10: unlambda: replace `func() time.Time {
	return time.Now()
}` with `time.Now` (gocritic)
		"now": func() time.Time {
		       ^
views/user.go:63:4: ifElseChain: rewrite if-else to switch statement (gocritic)
			if err != nil {
			^
views/user.go:94:3: ifElseChain: rewrite if-else to switch statement (gocritic)
		if valid {
		^
views/user.go:144:3: ifElseChain: rewrite if-else to switch statement (gocritic)
		if err != nil {
		^
user/keycloak.go:9: user/keycloak.go:9: Line contains TODO/BUG/FIXME: "TODO figure out what this is..." (godox)
// TODO figure out what this is...
views/login.go:39: views/login.go:39: Line contains TODO/BUG/FIXME: "TODO Don't call env in this function hav..." (godox)
	// TODO Don't call env in this function have an initialiser
views/signup.go:83: views/signup.go:83: Line contains TODO/BUG/FIXME: "TODO: Implement signup holding page" (godox)
//TODO: Implement signup holding page
role/role.go:4: File is not `goimports`-ed (goimports)
	"context"
permission/permission.go:4: File is not `goimports`-ed (goimports)
	"context"
user/db.go:6: File is not `goimports`-ed (goimports)
	"github.com/ystv/web-auth/role"
utils/random.go:15:21: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
		b.WriteRune(chars[rand.Intn(len(chars))])
		                  ^
infrastructure/mail/mail.go:54:51: G402: TLS InsecureSkipVerify set true. (gosec)
		TLSConfig:      &tls.Config{InsecureSkipVerify: true},
		                                                ^
views/internal.go:4:2: G501: Blocklisted import crypto/md5: weak cryptographic primitive (gosec)
	"crypto/md5"
	^
views/internal.go:108:11: G401: Use of weak cryptographic primitive (gosec)
		hash := md5.Sum([]byte(strings.ToLower(strings.TrimSpace("liam.burnand@bswdi.co.uk"))))
		        ^
views/user.go:4:2: G501: Blocklisted import crypto/md5: weak cryptographic primitive (gosec)
	"crypto/md5"
	^
views/user.go:323:11: G401: Use of weak cryptographic primitive (gosec)
		hash := md5.Sum([]byte(strings.ToLower(strings.TrimSpace(user1.Email))))
		        ^
main.go:170:12: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
	log.Fatal(http.ListenAndServe(":8080", mux1))
	          ^
views/helpers.go:38:2: Consider pre-allocating `tplUsers` (prealloc)
	var tplUsers []UserStripped
	^
role/role.go:25:2: exported: type name will be used as role.RolePermission by other packages, and that stutters; consider calling this Permission (revive)
	RolePermission struct {
	^
role/role.go:30:2: exported: type name will be used as role.RoleUser by other packages, and that stutters; consider calling this User (revive)
	RoleUser struct {
	^
views/middleware.go:60:17: var-naming: method RequiresMinimumPermissionNoHttp should be RequiresMinimumPermissionNoHTTP (revive)
func (v *Views) RequiresMinimumPermissionNoHttp(userID int, p permissions.Permissions) bool {
                ^
main.go:24:12: unused-parameter: parameter 'origin' seems to be unused, consider removing or renaming it as _ (revive)
func allow(origin string) bool {
           ^
user/keycloak.go:10:17: func `(*Store).newUser` is unused (unused)
func (s *Store) newUser(ctx context.Context, u User) error {
                ^
user/user.go:31:3: field `cloak` is unused (unused)
		cloak *gocloaksession.GoCloakSession
		^
views/api.go:37:30: Function `newJWT` should pass the context parameter (contextcheck)
	tokenString, err := v.newJWT(u)
	                            ^
views/internal.go:88:33: Function `RenderTemplate->RenderTemplate$11` should pass the context parameter (contextcheck)
	err = v.template.RenderTemplate(w, ctx, templates.InternalTemplate)
	                               ^
views/internal.go:119:34: Function `RenderTemplate->RenderTemplate$11` should pass the context parameter (contextcheck)
	err := v.template.RenderTemplate(w, ctx, templates.SettingsTemplate)
	                                ^
views/middleware.go:47:39: Function `RequiresMinimumPermissionNoHttp` should pass the context parameter (contextcheck)
		if v.RequiresMinimumPermissionNoHttp(u.UserID, p) {
		                                    ^
views/permission.go:33:33: Function `RenderTemplate->RenderTemplate$11` should pass the context parameter (contextcheck)
	err = v.template.RenderTemplate(w, data, templates.PermissionsTemplate)
	                               ^
views/user.go:270:43: Function `RenderTemplatePagination->RenderTemplatePagination$12` should pass the context parameter (contextcheck)
	err = v.template.RenderTemplatePagination(w, ctx, templates.UsersTemplate)
	                                         ^
views/signup.go:44:16: type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
			if _, ok := err.(*validator.ValidationErrors); ok {
			            ^
views/signup.go:50:24: type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
			for _, err := range err.(validator.ValidationErrors) {
			                    ^
user/keycloak.go:24:5: ineffectual assignment to err (ineffassign)
	_, err = client.CreateUser(ctx, token.AccessToken, "realName", user)
	   ^
helpers/user.go:13:6: ineffectual assignment to u (ineffassign)
	var u = user.User{}
	    ^
views/helpers.go:24:2: ineffectual assignment to u (ineffassign)
	u := user.User{}
	^
user/user.go:34:2: `User` should be annotated with the `db` tag as it is passed to `sqlx.DB.GetContext` at user/db.go:72:9 (musttag)
	User struct {
	^
views/user.go:118:5: SA4027: (*net/url.URL).Query returns a copy, modifying it doesn't change the URL (staticcheck)
				r.URL.Query().Del("*")
				^
```