### PR TITLE
Remove all HTTP errors that are conditional on debug

### DIFF
--- a/infrastructure/db/database.go
+++ b/infrastructure/db/database.go
@@ -9,14 +9,10 @@ import (
 )
 
 // NewStore initialises the store
-func NewStore(dataSourceName string, host string, debug bool) *sqlx.DB {
+func NewStore(dataSourceName string, host string) *sqlx.DB {
 	db, err := sqlx.ConnectContext(context.Background(), "postgres", dataSourceName)
 	if err != nil {
-		if debug {
-			log.Printf("db failed: %+v", err)
-		} else {
-			log.Fatalf("db failed: %+v", err)
-		}
+		log.Fatalf("db failed: %+v", err)
 	} else {
 		log.Printf("connected to db: %s", host)
 	}

--- a/views/forgot.go
+++ b/views/forgot.go
@@ -2,14 +2,15 @@ package views
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/patrickmn/go-cache"
+
 	"github.com/ystv/web-auth/infrastructure/mail"
 	"github.com/ystv/web-auth/templates"
 	"github.com/ystv/web-auth/user"
-	"log"
-	"net/http"
 )
 
 type (
@@ -54,7 +55,7 @@ func (v *Views) ForgotFunc(c echo.Context) error {
 		if mailer != nil {
 			emailTemplate, err := v.template.GetEmailTemplate(templates.ForgotEmailTemplate)
 			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to render email for forgot: %w", err))
+				return fmt.Errorf("failed to render email for forgot: %w", err)
 			}
 
 			file := mail.Mail{
@@ -74,7 +75,7 @@ func (v *Views) ForgotFunc(c echo.Context) error {
 			err = mailer.SendMail(file)
 			if err != nil {
 				log.Printf("failed to send mail for forgot: %+v", err)
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to send email for forgot: %w", err))
+				return fmt.Errorf("failed to send email for forgot: %w", err)
 			}
 			_ = mailer.Close()
 

--- a/views/internal.go
+++ b/views/internal.go
@@ -2,13 +2,14 @@ package views
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/labstack/echo/v4"
+
 	"github.com/ystv/web-auth/permission"
 	"github.com/ystv/web-auth/templates"
 	"github.com/ystv/web-auth/user"
-	"log"
-	"net/http"
-	"time"
 
 	"github.com/dustin/go-humanize"
 )
@@ -34,18 +35,12 @@ func (v *Views) InternalFunc(c echo.Context) error {
 
 	countAll, err := v.user.CountUsersAll(c.Request().Context())
 	if err != nil {
-		log.Println(err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get count users all for interal: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get count users all for interal: %w", err))
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get permissions for internal: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for internal: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for internal: %+v", err))
 	}
 
 	ctx := InternalTemplate{

--- a/views/internal.go
+++ b/views/internal.go
@@ -2,7 +2,6 @@ package views
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -35,12 +34,12 @@ func (v *Views) InternalFunc(c echo.Context) error {
 
 	countAll, err := v.user.CountUsersAll(c.Request().Context())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get count users all for interal: %w", err))
+		return fmt.Errorf("failed to get count users all for interal: %w", err)
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for internal: %+v", err))
+		return fmt.Errorf("failed to get permissions for internal: %+v", err)
 	}
 
 	ctx := InternalTemplate{

--- a/views/internal.go
+++ b/views/internal.go
@@ -39,7 +39,7 @@ func (v *Views) InternalFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return fmt.Errorf("failed to get permissions for internal: %+v", err)
+		return fmt.Errorf("failed to get permissions for internal: %w", err)
 	}
 
 	ctx := InternalTemplate{

--- a/views/login.go
+++ b/views/login.go
@@ -68,7 +68,7 @@ func (v *Views) LoginFunc(c echo.Context) error {
 			log.Printf("failed login for \"%s\": %v", u.Username, err)
 			err = session.Save(c.Request(), c.Response())
 			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to save session for login: %w", err))
+				return fmt.Errorf("failed to save session for login: %w", err)
 			}
 
 			if resetPw {
@@ -93,7 +93,7 @@ func (v *Views) LoginFunc(c echo.Context) error {
 		err = v.user.SetUserLoggedIn(c.Request().Context(), u)
 		if err != nil {
 			err = fmt.Errorf("failed to set user logged in: %w", err)
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to set user logged in for login: %w", err))
+			return fmt.Errorf("failed to set user logged in for login: %w", err)
 		}
 		u.Authenticated = true
 		// This is a bit of a cheat, just so we can have the last login displayed for internal
@@ -106,7 +106,7 @@ func (v *Views) LoginFunc(c echo.Context) error {
 
 		err = session.Save(c.Request(), c.Response())
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to save user session for login: %w", err))
+			return fmt.Errorf("failed to save user session for login: %w", err)
 		}
 
 		log.Printf("user \"%s\" is authenticated", u.Username)

--- a/views/logout.go
+++ b/views/logout.go
@@ -12,14 +12,14 @@ import (
 func (v *Views) LogoutFunc(c echo.Context) error {
 	session, err := v.cookie.Get(c.Request(), v.conf.SessionCookieName)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get session for logout: %w", err))
+		return fmt.Errorf("failed to get session for logout: %w", err)
 	}
 
 	session.Values["user"] = user.User{}
 	session.Options.MaxAge = -1
 	err = session.Save(c.Request(), c.Response())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to save session for logout: %w", err))
+		return fmt.Errorf("failed to save session for logout: %w", err)
 	}
 	endpoint := v.conf.LogoutEndpoint
 	if endpoint == "" {

--- a/views/middleware.go
+++ b/views/middleware.go
@@ -34,7 +34,7 @@ func (v *Views) RequiresLogin(next echo.HandlerFunc) echo.HandlerFunc {
 			session.Options.MaxAge = -1
 			err = session.Save(c.Request(), c.Response())
 			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to save session for requiresLogin: %w", err))
+				return fmt.Errorf("failed to save session for requiresLogin: %w", err)
 			}
 			return c.Redirect(http.StatusFound, "/")
 		}
@@ -108,11 +108,11 @@ func (v *Views) RequirePermission(p permissions.Permissions) echo.MiddlewareFunc
 		return func(c echo.Context) error {
 			c1 := v.getSessionData(c)
 			if c1 == nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get session data"))
+				return fmt.Errorf("failed to get session data")
 			}
 			perms, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for requirePermission: %w", err))
+				return fmt.Errorf("failed to get permissions for requirePermission: %w", err)
 			}
 
 			acceptedPerms := permission.SufficientPermissionsFor(p)

--- a/views/permission.go
+++ b/views/permission.go
@@ -2,13 +2,14 @@ package views
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/labstack/echo/v4"
+
 	"github.com/ystv/web-auth/permission"
 	"github.com/ystv/web-auth/templates"
 	"github.com/ystv/web-auth/user"
-	"log"
-	"net/http"
-	"strconv"
 )
 
 type (
@@ -39,18 +40,12 @@ func (v *Views) PermissionsFunc(c echo.Context) error {
 
 	permissions, err := v.permission.GetPermissions(c.Request().Context())
 	if err != nil {
-		log.Printf("failed to get permissions for permissions: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for permissions: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for permissions: %w", err))
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get user permissions for permissions: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for permissions: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for permissions: %+v", err))
 	}
 
 	data := PermissionsTemplate{
@@ -68,36 +63,24 @@ func (v *Views) PermissionFunc(c echo.Context) error {
 
 	permissionID, err := strconv.Atoi(c.Param("permissionid"))
 	if err != nil {
-		log.Printf("failed to get permissionid for permission: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to parse permissionid for permission: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to parse permissionid for permission: %w", err))
 	}
 
 	permission1, err := v.permission.GetPermission(c.Request().Context(), permission.Permission{PermissionID: permissionID})
 	if err != nil {
-		log.Printf("failed to get permission for permission: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permission for permission: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permission for permission: %w", err))
 	}
 
 	permissionTemplate := v.bindPermissionToTemplate(permission1)
 
 	permissionTemplate.Roles, err = v.user.GetRolesForPermission(c.Request().Context(), permission1)
 	if err != nil {
-		log.Printf("failed to get roles for permission: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for permission: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for permission: %w", err))
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get user permissions for permission: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for permission: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for permission: %+v", err))
 	}
 
 	data := PermissionTemplate{

--- a/views/permission.go
+++ b/views/permission.go
@@ -2,7 +2,6 @@ package views
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
@@ -40,12 +39,12 @@ func (v *Views) PermissionsFunc(c echo.Context) error {
 
 	permissions, err := v.permission.GetPermissions(c.Request().Context())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for permissions: %w", err))
+		return fmt.Errorf("failed to get permissions for permissions: %w", err)
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for permissions: %+v", err))
+		return fmt.Errorf("failed to get user permissions for permissions: %+v", err)
 	}
 
 	data := PermissionsTemplate{
@@ -63,24 +62,24 @@ func (v *Views) PermissionFunc(c echo.Context) error {
 
 	permissionID, err := strconv.Atoi(c.Param("permissionid"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to parse permissionid for permission: %w", err))
+		return fmt.Errorf("failed to parse permissionid for permission: %w", err)
 	}
 
 	permission1, err := v.permission.GetPermission(c.Request().Context(), permission.Permission{PermissionID: permissionID})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permission for permission: %w", err))
+		return fmt.Errorf("failed to get permission for permission: %w", err)
 	}
 
 	permissionTemplate := v.bindPermissionToTemplate(permission1)
 
 	permissionTemplate.Roles, err = v.user.GetRolesForPermission(c.Request().Context(), permission1)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for permission: %w", err))
+		return fmt.Errorf("failed to get roles for permission: %w", err)
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for permission: %+v", err))
+		return fmt.Errorf("failed to get user permissions for permission: %+v", err)
 	}
 
 	data := PermissionTemplate{

--- a/views/permission.go
+++ b/views/permission.go
@@ -44,7 +44,7 @@ func (v *Views) PermissionsFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return fmt.Errorf("failed to get user permissions for permissions: %+v", err)
+		return fmt.Errorf("failed to get user permissions for permissions: %w", err)
 	}
 
 	data := PermissionsTemplate{
@@ -79,7 +79,7 @@ func (v *Views) PermissionFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return fmt.Errorf("failed to get user permissions for permission: %+v", err)
+		return fmt.Errorf("failed to get user permissions for permission: %w", err)
 	}
 
 	data := PermissionTemplate{

--- a/views/reset.go
+++ b/views/reset.go
@@ -19,13 +19,13 @@ func (v *Views) ResetURLFunc(c echo.Context) error {
 
 	userID, found := v.cache.Get(url)
 	if !found {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get url for reset"))
+		return fmt.Errorf("failed to get url for reset")
 	}
 
 	originalUser, err := v.user.GetUser(c.Request().Context(), user.User{UserID: userID.(int)})
 	if err != nil {
 		v.cache.Delete(url)
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("url is invalid, failed to get user : %w", err))
+		return fmt.Errorf("url is invalid, failed to get user : %w", err)
 	}
 
 	switch c.Request().Method {
@@ -55,19 +55,19 @@ func (v *Views) ResetUserPasswordFunc(c echo.Context) error {
 
 	userID, err := strconv.Atoi(c.Param("userid"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to parse userid for reset: %w", err))
+		return fmt.Errorf("failed to parse userid for reset: %w", err)
 	}
 
 	userFromDB, err := v.user.GetUser(c.Request().Context(), user.User{UserID: userID})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user for reset: %w", err))
+		return fmt.Errorf("failed to get user for reset: %w", err)
 	}
 
 	userFromDB.ResetPw = true
 
 	_, err = v.user.UpdateUser(c.Request().Context(), userFromDB, c1.User.UserID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update user for reset: %w", err))
+		return fmt.Errorf("failed to update user for reset: %w", err)
 	}
 
 	url := uuid.NewString()
@@ -86,7 +86,7 @@ func (v *Views) ResetUserPasswordFunc(c echo.Context) error {
 	if mailer != nil {
 		emailTemplate, err := v.template.GetEmailTemplate(templates.ResetEmailTemplate)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to render email for reset: %w", err))
+			return fmt.Errorf("failed to render email for reset: %w", err)
 		}
 
 		file := mail.Mail{

--- a/views/role.go
+++ b/views/role.go
@@ -2,14 +2,15 @@ package views
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/labstack/echo/v4"
+
 	"github.com/ystv/web-auth/permission"
 	"github.com/ystv/web-auth/role"
 	"github.com/ystv/web-auth/templates"
 	"github.com/ystv/web-auth/user"
-	"log"
-	"net/http"
-	"strconv"
 )
 
 type (
@@ -40,18 +41,12 @@ func (v *Views) RolesFunc(c echo.Context) error {
 
 	roles, err := v.role.GetRoles(c.Request().Context())
 	if err != nil {
-		log.Printf("failed to get roles for roles: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for roles: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for roles: %w", err))
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get user permissions for roles: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for roles: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for roles: %+v", err))
 	}
 
 	data := RolesTemplate{
@@ -68,44 +63,29 @@ func (v *Views) RoleFunc(c echo.Context) error {
 
 	roleID, err := strconv.Atoi(c.Param("roleid"))
 	if err != nil {
-		log.Printf("failed to get roleid for role: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roleid for role: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roleid for role: %w", err))
 	}
 
 	role1, err := v.role.GetRole(c.Request().Context(), role.Role{RoleID: roleID})
 	if err != nil {
-		log.Printf("failed to get role for role: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get role for role: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get role for role: %w", err))
 	}
 
 	roleTemplate := v.bindRoleToTemplate(role1)
 
 	roleTemplate.Permissions, err = v.user.GetPermissionsForRole(c.Request().Context(), role1)
 	if err != nil {
-		log.Printf("failed to get permissions for role: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to permissions for role: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to permissions for role: %w", err))
 	}
 
 	roleTemplate.Users, err = v.user.GetUsersForRole(c.Request().Context(), role1)
 	if err != nil {
-		log.Printf("failed to get users for role: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for role: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for role: %w", err))
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get user permissions for role: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for role: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for role: %+v", err))
 	}
 
 	data := RoleTemplate{

--- a/views/role.go
+++ b/views/role.go
@@ -45,7 +45,7 @@ func (v *Views) RolesFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return fmt.Errorf("failed to get user permissions for roles: %+v", err)
+		return fmt.Errorf("failed to get user permissions for roles: %w", err)
 	}
 
 	data := RolesTemplate{
@@ -84,7 +84,7 @@ func (v *Views) RoleFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return fmt.Errorf("failed to get user permissions for role: %+v", err)
+		return fmt.Errorf("failed to get user permissions for role: %w", err)
 	}
 
 	data := RoleTemplate{

--- a/views/role.go
+++ b/views/role.go
@@ -2,7 +2,6 @@ package views
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
@@ -41,12 +40,12 @@ func (v *Views) RolesFunc(c echo.Context) error {
 
 	roles, err := v.role.GetRoles(c.Request().Context())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for roles: %w", err))
+		return fmt.Errorf("failed to get roles for roles: %w", err)
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for roles: %+v", err))
+		return fmt.Errorf("failed to get user permissions for roles: %+v", err)
 	}
 
 	data := RolesTemplate{
@@ -63,29 +62,29 @@ func (v *Views) RoleFunc(c echo.Context) error {
 
 	roleID, err := strconv.Atoi(c.Param("roleid"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roleid for role: %w", err))
+		return fmt.Errorf("failed to get roleid for role: %w", err)
 	}
 
 	role1, err := v.role.GetRole(c.Request().Context(), role.Role{RoleID: roleID})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get role for role: %w", err))
+		return fmt.Errorf("failed to get role for role: %w", err)
 	}
 
 	roleTemplate := v.bindRoleToTemplate(role1)
 
 	roleTemplate.Permissions, err = v.user.GetPermissionsForRole(c.Request().Context(), role1)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to permissions for role: %w", err))
+		return fmt.Errorf("failed to permissions for role: %w", err)
 	}
 
 	roleTemplate.Users, err = v.user.GetUsersForRole(c.Request().Context(), role1)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for role: %w", err))
+		return fmt.Errorf("failed to get users for role: %w", err)
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for role: %+v", err))
+		return fmt.Errorf("failed to get user permissions for role: %+v", err)
 	}
 
 	data := RoleTemplate{

--- a/views/settings.go
+++ b/views/settings.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -43,7 +42,7 @@ func (v *Views) SettingsFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for settings: %w", err))
+		return fmt.Errorf("failed to get user permissions for settings: %w", err)
 	}
 
 	ctx := SettingsTemplate{

--- a/views/settings.go
+++ b/views/settings.go
@@ -4,15 +4,16 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"github.com/dustin/go-humanize"
-	"github.com/labstack/echo/v4"
-	"github.com/ystv/web-auth/permission"
-	"github.com/ystv/web-auth/templates"
-	"github.com/ystv/web-auth/user"
-	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/labstack/echo/v4"
+
+	"github.com/ystv/web-auth/permission"
+	"github.com/ystv/web-auth/templates"
+	"github.com/ystv/web-auth/user"
 )
 
 type (
@@ -42,10 +43,7 @@ func (v *Views) SettingsFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get user permissions for settings: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for settings: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for settings: %w", err))
 	}
 
 	ctx := SettingsTemplate{

--- a/views/signup.go
+++ b/views/signup.go
@@ -37,7 +37,7 @@ func (v *Views) SignUpFunc(c echo.Context) error {
 		if err != nil {
 			var validationErrors *validator.ValidationErrors
 			if errors.As(err, &validationErrors) {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to validate: %w", err))
+				return fmt.Errorf("failed to validate: %w", err)
 			}
 			issues := ""
 			for _, err := range err.(validator.ValidationErrors) {

--- a/views/user.go
+++ b/views/user.go
@@ -145,7 +145,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 
 		countAll, err = v.user.CountUsersAll(c.Request().Context())
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get total users for users: %w", err))
+			return fmt.Errorf("failed to get total users for users: %w", err)
 		}
 
 		count = countAll.TotalUsers
@@ -179,11 +179,11 @@ func (v *Views) UsersFunc(c echo.Context) error {
 			if size > 0 && page > 0 {
 				dbUsers, err = v.user.GetUsersSortedSearchSizePage(c.Request().Context(), column, direction, search, size, page)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
+					return fmt.Errorf("failed to get users for users: %w", err)
 				}
 				tmp, err := v.user.GetUsersSortedSearch(c.Request().Context(), column, direction, search)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
+					return fmt.Errorf("failed to get users for users: %w", err)
 				}
 				count = len(tmp)
 			} else {
@@ -201,7 +201,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 			dbUsers, err = v.user.GetUsersSearchSizePage(c.Request().Context(), search, size, page)
 			tmp, err := v.user.GetUsersSearch(c.Request().Context(), search)
 			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
+				return fmt.Errorf("failed to get users for users: %w", err)
 			}
 			count = len(tmp)
 		} else {
@@ -216,7 +216,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 	}
 
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
+		return fmt.Errorf("failed to get users for users: %w", err)
 	}
 	tplUsers := DBUsersToUsersTemplateFormat(dbUsers)
 
@@ -234,7 +234,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for users: %+v", err))
+		return fmt.Errorf("failed to get user permissions for users: %+v", err)
 	}
 
 	data := UsersTemplate{
@@ -265,26 +265,26 @@ func (v *Views) UserFunc(c echo.Context) error {
 	}
 	userFromDB, err := v.user.GetUser(c.Request().Context(), user.User{UserID: userID})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user for user: %w", err))
+		return fmt.Errorf("failed to get user for user: %w", err)
 	}
 
 	detailedUser := DBUserToUserTemplateFormat(userFromDB, v.user)
 
 	detailedUser.Permissions, err = v.user.GetPermissionsForUser(c.Request().Context(), user.User{UserID: detailedUser.UserID})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for user: %w", err))
+		return fmt.Errorf("failed to get permissions for user: %w", err)
 	}
 
 	detailedUser.Permissions = v.removeDuplicate(detailedUser.Permissions)
 
 	detailedUser.Roles, err = v.user.GetRolesForUser(c.Request().Context(), user.User{UserID: detailedUser.UserID})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for user: %w", err))
+		return fmt.Errorf("failed to get roles for user: %w", err)
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for user: %+v", err))
+		return fmt.Errorf("failed to get user permissions for user: %+v", err)
 	}
 
 	data := UserTemplate{

--- a/views/user.go
+++ b/views/user.go
@@ -2,15 +2,16 @@ package views
 
 import (
 	"fmt"
-	"github.com/labstack/echo/v4"
-	"github.com/ystv/web-auth/permission"
-	"github.com/ystv/web-auth/templates"
-	"github.com/ystv/web-auth/user"
-	"log"
 	"math"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/ystv/web-auth/permission"
+	"github.com/ystv/web-auth/templates"
+	"github.com/ystv/web-auth/user"
 )
 
 type (
@@ -178,17 +179,11 @@ func (v *Views) UsersFunc(c echo.Context) error {
 			if size > 0 && page > 0 {
 				dbUsers, err = v.user.GetUsersSortedSearchSizePage(c.Request().Context(), column, direction, search, size, page)
 				if err != nil {
-					log.Println(err)
-					if !v.conf.Debug {
-						return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
-					}
+					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
 				}
 				tmp, err := v.user.GetUsersSortedSearch(c.Request().Context(), column, direction, search)
 				if err != nil {
-					log.Println(err)
-					if !v.conf.Debug {
-						return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
-					}
+					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
 				}
 				count = len(tmp)
 			} else {
@@ -206,10 +201,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 			dbUsers, err = v.user.GetUsersSearchSizePage(c.Request().Context(), search, size, page)
 			tmp, err := v.user.GetUsersSearch(c.Request().Context(), search)
 			if err != nil {
-				log.Println(err)
-				if !v.conf.Debug {
-					return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
-				}
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
 			}
 			count = len(tmp)
 		} else {
@@ -224,10 +216,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 	}
 
 	if err != nil {
-		log.Println(err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get users for users: %w", err))
 	}
 	tplUsers := DBUsersToUsersTemplateFormat(dbUsers)
 
@@ -245,10 +234,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get user permissions for users: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for users: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for users: %+v", err))
 	}
 
 	data := UsersTemplate{
@@ -279,38 +265,26 @@ func (v *Views) UserFunc(c echo.Context) error {
 	}
 	userFromDB, err := v.user.GetUser(c.Request().Context(), user.User{UserID: userID})
 	if err != nil {
-		log.Printf("failed to get user in user: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user for user: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user for user: %w", err))
 	}
 
 	detailedUser := DBUserToUserTemplateFormat(userFromDB, v.user)
 
 	detailedUser.Permissions, err = v.user.GetPermissionsForUser(c.Request().Context(), user.User{UserID: detailedUser.UserID})
 	if err != nil {
-		log.Println(err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for user: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get permissions for user: %w", err))
 	}
 
 	detailedUser.Permissions = v.removeDuplicate(detailedUser.Permissions)
 
 	detailedUser.Roles, err = v.user.GetRolesForUser(c.Request().Context(), user.User{UserID: detailedUser.UserID})
 	if err != nil {
-		log.Println(err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for user: %w", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get roles for user: %w", err))
 	}
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		log.Printf("failed to get user permissions for user: %+v", err)
-		if !v.conf.Debug {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for user: %+v", err))
-		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get user permissions for user: %+v", err))
 	}
 
 	data := UserTemplate{

--- a/views/user.go
+++ b/views/user.go
@@ -234,7 +234,7 @@ func (v *Views) UsersFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return fmt.Errorf("failed to get user permissions for users: %+v", err)
+		return fmt.Errorf("failed to get user permissions for users: %w", err)
 	}
 
 	data := UsersTemplate{
@@ -284,7 +284,7 @@ func (v *Views) UserFunc(c echo.Context) error {
 
 	p1, err := v.user.GetPermissionsForUser(c.Request().Context(), c1.User)
 	if err != nil {
-		return fmt.Errorf("failed to get user permissions for user: %+v", err)
+		return fmt.Errorf("failed to get user permissions for user: %w", err)
 	}
 
 	data := UserTemplate{

--- a/views/views.go
+++ b/views/views.go
@@ -3,16 +3,18 @@ package views
 import (
 	"encoding/gob"
 	"encoding/hex"
+	"time"
+
 	"github.com/ystv/web-auth/infrastructure/mail"
 	"github.com/ystv/web-auth/permission"
 	"github.com/ystv/web-auth/role"
 	"github.com/ystv/web-auth/templates"
-	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/patrickmn/go-cache"
+
 	"github.com/ystv/web-auth/infrastructure/db"
 	"github.com/ystv/web-auth/user"
 )
@@ -66,7 +68,7 @@ type (
 func New(conf *Config, host string) *Views {
 	v := &Views{}
 	// Connecting to stores
-	dbStore := db.NewStore(conf.DatabaseURL, host, conf.Debug)
+	dbStore := db.NewStore(conf.DatabaseURL, host)
 	v.permission = permission.NewPermissionRepo(dbStore)
 	v.role = role.NewRoleRepo(dbStore)
 	v.user = user.NewUserRepo(dbStore)


### PR DESCRIPTION
Per Slack:

> To expand a bit on my stance on the debug-only stuff (apologies for making you do more work, but this is a hill I will die on): any difference between development and production is a potential bug, so we need to be very careful - in particular where things like error handling and control flow are changed (because how are you meant to test error handling if the error handling is skipped in debug)
> 
> If setting up the database is too hard, that’s a problem we need to fix, not work around.
>
> Email I could see a case for disabling, though the ideal case would be something like https://github.com/mailhog/MailHog set up - again, means you can test that email works, instead of leaving it until production.
>
> I’d even go so far as to say that the conditional permissions stuff in router is a bit sketchy, because it means you can’t (easily) test that the permissions checks are right - better to have some easy way to make a full-permissions user (make it a command-line thing so there’s zero added code to the deployed app). Though I’m happy to leave that in.

This also replaces all instances of `return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf(...))` with `return fmt.Errorf(...)` - they are equivalent with our error handler. This was done automatically using `gofmt -w -r 'echo.NewHTTPError(http.StatusInternalServerError, a) -> a' **/*.go`.